### PR TITLE
Add support for Ansible-lint 6.13.1

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -7,3 +7,7 @@ exclude_paths:
   - .pre-commit-config.yaml
   - .github/
 offline: true
+
+warn_list:  # TODO: fix warnings from ansible-lint 6.13.1 using ansible 2.13.7 & incl. to tox.ini
+  - fqcn[action-core]
+  - name[template]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,7 +29,7 @@ restic_prometehus_exporter_script: '{{ restic_script_dir }}/restic_prometehus_ex
 restic_prometehus_exporter_metrics_basedir: /var/lib/node-exporter
 
 restic_failure_template: restic_failure_unit.j2
-restic_failure_script: '{{restic_script_dir }}/unit-failure'
+restic_failure_script: '{{ restic_script_dir }}/unit-failure'
 restic_failure_mail_to: "root"
 
 restic_non_root_setup: false

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -50,7 +50,7 @@
         update_cache: true
       changed_when: false
       when: ansible_distribution in ["Debian", "Ubuntu"]
-    - name: Install dependencies 
+    - name: Install dependencies
       package:
         name: "{{ item }}"
         state: present

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,6 +4,7 @@
     url: '{{ restic_url }}'
     dest: '{{ restic_download_path }}/restic.bz2'
     checksum: "sha256:{{ restic_url_checksums }}"
+    mode: "0644"
   register: get_url_restic
 
 - name: Install restic

--- a/tasks/restic.yml
+++ b/tasks/restic.yml
@@ -1,7 +1,7 @@
 ---
 - name: Reformat dict if necessary
   set_fact:
-    restic_backups: '{{ restic_backups|dict2items|json_query("[*].value") }}'
+    restic_backups: '{{ restic_backups | dict2items | json_query("[*].value") }}'
   when:
     - restic_backups | type_debug == "dict"
 


### PR DESCRIPTION
I've fixed some lint errors & add 2 to warn list. These 2 rules require some more testing. I'll leave it for when we integrate it with the tox.ini so we have a new test env for the newer Ansible version.

Here you can see the details of the rules I've moved to the warn level:
- https://ansible-lint.readthedocs.io/rules/fqcn/
- https://ansible-lint.readthedocs.io/rules/name/