### PR TITLE
Fix spelling prometheus & add cpu limit (GOMAXPROCS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This scripts will be stored in a configurable scripts directory:
 | `restic_failure_mail_to` | `root` ||
 | `restic_non_root_setup` | `false` | Installs Restic as a specific user with read-only rights. (See [restic docs](https://restic.readthedocs.io/en/stable/080_examples.html#backing-up-your-system-without-running-restic-as-root))|
 | `restic_non_root_setup_user` | `restic` ||
+| `restic_gomaxprocs` | not defined | By default, restic [uses all available CPU cores](https://restic.readthedocs.io/en/stable/047_tuning_backup_parameters.html#cpu-usage). Use this variable to limit the number of used CPU cores.   |
 
 ### Repos
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ This scripts will be stored in a configurable scripts directory:
 | `restic_systemd_service_template` | `systemd_service.unit.j2` | Template for systemd restic backup service called by timer      |
 | `restic_systemd_failure_service_template` | `systemd_failure.unit.j2` | Template for systemd on error handling                  |
 | `restic_systemd_failure_service_name` | `restic-backup-failure@.service` | Name of systemd service to handle errors             |
-| `restic_prometehus_exporter_enabled` | `false` ||
-| `restic_prometehus_exporter_template`| `restic_prometehus_exporter.j2` ||
-| `restic_prometehus_exporter_script` | `{{ restic_script_dir }}/restic_prometehus_exporter.sh` ||
-| `restic_prometehus_exporter_metrics_basedir` | `/var/lib/node-exporter` ||
+| `restic_prometheus_exporter_enabled` | `false` ||
+| `restic_prometheus_exporter_template`| `restic_prometheus_exporter.j2` ||
+| `restic_prometheus_exporter_script` | `{{ restic_script_dir }}/restic_prometheus_exporter.sh` ||
+| `restic_prometheus_exporter_metrics_basedir` | `/var/lib/node-exporter` ||
 | `restic_failure_template` | `restic_failure_unit.j2` ||
 | `restic_failure_script` | `{{restic_script_dir }}/unit-failure` ||
 | `restic_failure_mail_to` | `root` ||

--- a/tasks/prometheus.yml
+++ b/tasks/prometheus.yml
@@ -17,7 +17,7 @@
       ansible.builtin.package:
         name: jq
 
-- name: Ensure prometehus metrics file can be created
+- name: Ensure prometheus metrics file can be created
   ansible.builtin.file:
     state: 'directory'
     path: '{{ restic_prometheus_exporter_metrics_basedir }}'
@@ -25,7 +25,7 @@
     owner: 'root'
     group: 'root'
 
-- name: Configure prometehus exporter script
+- name: Configure prometheus exporter script
   ansible.builtin.template:
     src: '{{ restic_prometheus_exporter_template }}'
     dest: '{{ restic_prometheus_exporter_script }}'

--- a/templates/restic_access.j2
+++ b/templates/restic_access.j2
@@ -22,6 +22,9 @@ export B2_ACCOUNT_ID='{{ restic_repos[item.repo].b2_account_id }}'
 {% if restic_repos[item.repo].b2_account_key is defined %}
 export B2_ACCOUNT_KEY='{{ restic_repos[item.repo].b2_account_key }}'
 {% endif %}
+{% if restic_gomaxprocs is defined %}
+export GOMAXPROCS={{ restic_gomaxprocs }}
+{% endif %}
 BACKUP_NAME='{{ item.name }}'
 {% if item.src is defined %}
 BACKUP_SOURCE='{{ item.src }}'


### PR DESCRIPTION
By default, restic [uses all available CPU cores](https://restic.readthedocs.io/en/stable/047_tuning_backup_parameters.html#cpu-usage). I added the variable to limit the number of used CPU cores.